### PR TITLE
Add Bootstrap CV page with home layout and experience tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,60 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Mihir Rao - CV</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
 <body>
-<h1>Hello World</h1>
-<p>I'm hosted with GitHub Pages.</p>
+  <div class="container py-5">
+    <h1 class="mb-4">Mihir Rao</h1>
+    <ul class="nav nav-tabs" id="cvTabs" role="tablist">
+      <li class="nav-item" role="presentation">
+        <button class="nav-link active" id="home-tab" data-bs-toggle="tab" data-bs-target="#home" type="button" role="tab" aria-controls="home" aria-selected="true">Home</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="education-tab" data-bs-toggle="tab" data-bs-target="#education" type="button" role="tab" aria-controls="education" aria-selected="false">Education</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="awards-tab" data-bs-toggle="tab" data-bs-target="#awards" type="button" role="tab" aria-controls="awards" aria-selected="false">Awards</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="experience-tab" data-bs-toggle="tab" data-bs-target="#experience" type="button" role="tab" aria-controls="experience" aria-selected="false">Experience</button>
+      </li>
+    </ul>
+    <div class="tab-content pt-3" id="cvTabsContent">
+      <div class="tab-pane fade show active" id="home" role="tabpanel" aria-labelledby="home-tab">
+        <div class="row align-items-center">
+          <div class="col-md-4">
+            <img src="https://via.placeholder.com/150" class="img-fluid rounded" alt="Profile picture">
+          </div>
+          <div class="col-md-8">
+            <p>Placeholder for a short academic biography and research interests.</p>
+          </div>
+        </div>
+      </div>
+      <div class="tab-pane fade" id="education" role="tabpanel" aria-labelledby="education-tab">
+        <ul>
+          <li>Ph.D. in Placeholder Studies, University of Somewhere, 2025</li>
+          <li>B.S. in Sample Sciences, Institute of Examples, 2020</li>
+        </ul>
+      </div>
+      <div class="tab-pane fade" id="awards" role="tabpanel" aria-labelledby="awards-tab">
+        <ul>
+          <li>Recipient of the Imaginary Fellowship, 2024</li>
+          <li>Best Paper Award at Sample Conference, 2023</li>
+        </ul>
+      </div>
+      <div class="tab-pane fade" id="experience" role="tabpanel" aria-labelledby="experience-tab">
+        <ul>
+          <li>Acme Corp - Software Engineer, Jan 2020 - Dec 2021</li>
+          <li>Widget Inc - Senior Developer, Jan 2022 - Jun 2023</li>
+          <li>Tech Solutions - Intern, Jun 2019 - Dec 2019</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rename About Me tab to Home with photo and bio layout
- add Experience tab listing sample work history

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896d2f38a3483279ae17b2bbbb65810