### PR TITLE
Remove auction mechanisms project

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,6 @@ candidates. Visitors can search and filter by category, company, and their
 browser-local applied state; exact `City, ST` locations remain visible on every
 listing.
 
-The Personal Projects section also links to the standalone interactive essay
-**Can an Auction Make Bidders Tell the Truth?** at
-[`/learning-in-auction-mechanisms/`](https://mihirrao-10.github.io/learning-in-auction-mechanisms/).
-Its simulator, tests, generated story data, and GitHub Pages workflow live in the
-sibling `learning-in-auction-mechanisms` repository rather than this homepage
-repository.
-
 It also links to **The Shortest Path Through a Curved World** at
 [`/shortest-path-through-a-curved-world/`](https://mihirrao-10.github.io/shortest-path-through-a-curved-world/),
 a guided Heat Method story backed by a standalone C++20 CPU geometry engine

--- a/index.html
+++ b/index.html
@@ -339,18 +339,6 @@
       <div class="entry">
         <div class="entry-header">
           <h3 class="entry-title">
-            <a class="project-link" href="https://mihirrao-10.github.io/learning-in-auction-mechanisms/">Can an Auction Make Bidders Tell the Truth?</a>
-          </h3>
-        </div>
-        <p class="entry-detail">
-          A guided simulation of how learning bidders respond to first-price and second-price rules, and why the payment rule can make truthful bidding strategically optimal.
-        </p>
-        <p class="project-tags">Python · Multi-Agent Learning · Mechanism Design · Game Theory</p>
-      </div>
-
-      <div class="entry">
-        <div class="entry-header">
-          <h3 class="entry-title">
             <a class="project-link" href="new-grad-job-tracker-2027/">New Graduate Job Tracker (2027)</a>
           </h3>
         </div>


### PR DESCRIPTION
## Summary

Removes the Learning in Auction Mechanisms project from the personal website’s project list and documentation.

## Why

The standalone project has been removed locally and should no longer be presented on the website.

## Validation

- `npm test` (37 passing)
- Confirmed no remaining website references to the project