### PR TITLE
Add congestion MARL project to portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ on a generated toroidal mesh.
 That implementation, its exported numerical data, and its Pages workflow live
 in the sibling `shortest-path-through-a-curved-world` repository.
 
+The Personal Projects section also links to **When Every Agent Finds the
+Shortcut** at
+[`/multi-agent-reinforcement-learning-in-congestion-games/`](https://mihirrao-10.github.io/multi-agent-reinforcement-learning-in-congestion-games/),
+an exact atomic Braess-game study with deterministic multi-agent learning
+experiments and an interactive Three.js potential landscape. Its Python
+analysis, exported story data, web experience, tests, and Pages workflow live in
+the sibling `multi-agent-reinforcement-learning-in-congestion-games` repository.
+
 ## Repository layout
 
 ```text

--- a/index.html
+++ b/index.html
@@ -339,6 +339,18 @@
       <div class="entry">
         <div class="entry-header">
           <h3 class="entry-title">
+            <a class="project-link" href="https://mihirrao-10.github.io/multi-agent-reinforcement-learning-in-congestion-games/">When Every Agent Finds the Shortcut</a>
+          </h3>
+        </div>
+        <p class="entry-detail">
+          An exact finite congestion-game study where 80 independent learners discover Braess's paradox, with reproducible multi-seed experiments and an interactive potential landscape.
+        </p>
+        <p class="project-tags">Python · Multi-Agent Reinforcement Learning · Congestion Games · Three.js</p>
+      </div>
+
+      <div class="entry">
+        <div class="entry-header">
+          <h3 class="entry-title">
             <a class="project-link" href="new-grad-job-tracker-2027/">New Graduate Job Tracker (2027)</a>
           </h3>
         </div>


### PR DESCRIPTION
## Summary

- adds “When Every Agent Finds the Shortcut” to the Personal Projects section
- links the portfolio entry to the deployed congestion-game learning experience
- documents the sibling project repository and its reproducible research scope

## Why

The congestion-game MARL project is a résumé project alongside “The Shortest Path Through a Curved World” and should be discoverable from the main portfolio.

## Validation

- `npm run check`
- 37 Node tests passed
- production build contains the new public project link